### PR TITLE
Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+config_parser.dSYM/
+config_parser
+config_parser_test
+gtest-all.o
+libgtest.a

--- a/config_parser.cc
+++ b/config_parser.cc
@@ -212,11 +212,14 @@ bool NginxConfigParser::Parse(std::istream* config_file, NginxConfig* config) {
       config_stack.pop();
       unmatchedBrackets--;
     } else if (token_type == TOKEN_TYPE_EOF) {
-      if ((last_token_type != TOKEN_TYPE_STATEMENT_END &&
-          last_token_type != TOKEN_TYPE_END_BLOCK)
-        || unmatchedBrackets != 0) { // Number of starting brackets must match closing brackets
+      if (last_token_type != TOKEN_TYPE_STATEMENT_END &&
+          last_token_type != TOKEN_TYPE_END_BLOCK) {
         // Error.
         break;
+      }
+      if (unmatchedBrackets != 0) {
+        printf("Number of starting brackets must match closing brackets");
+        return false;
       }
       return true;
     } else {

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -5,23 +5,38 @@
     BASIC TESTS
 *****************************************************************************/
 
-TEST(NginxConfigParserTest, SimpleConfig) {
+// Tests basic config with a single statement
+TEST(NginxConfigParserTest, ParseSimpleConfig) {
   NginxConfigParser parser;
   NginxConfig out_config;
   EXPECT_TRUE(parser.Parse("example_config", &out_config));
 }
 
-TEST(NginxConfigParserTest, ToString) {
+// Tests ToString method on simple config
+TEST(NginxConfigParserTest, ToStringSimple) {
 	NginxConfigStatement statement;
 	statement.tokens_.push_back("foo");
 	statement.tokens_.push_back("bar");
 	EXPECT_EQ(statement.ToString(0), "foo bar;\n");
 }
 
+// Tests ToString method on config with a block
+TEST(NginxConfigParserTest, ToStringBlock) {
+	NginxConfigStatement statement;
+	statement.tokens_.push_back("server");
+	statement.tokens_.push_back("{");
+	statement.tokens_.push_back("listen");
+	statement.tokens_.push_back("80");
+	statement.tokens_.push_back(";");
+	statement.tokens_.push_back("}");
+	EXPECT_EQ(statement.ToString(0), "server { listen 80 ; };\n");
+}
+
 /*****************************************************************************
     PARSING STRINGS
 *****************************************************************************/
 
+// Test fixture for parsing strings
 class NginxStringConfigTest : public ::testing::Test {
 protected:
 	bool ParseString(const std::string config_string) {
@@ -32,26 +47,67 @@ protected:
 	NginxConfig out_config_;
 };
 
-TEST_F(NginxStringConfigTest, Statements) {
+// Verify config parser correctly separates a simple statement into tokens
+TEST_F(NginxStringConfigTest, SimpleConfigValid) {
 	EXPECT_TRUE(ParseString("foo bar;"));
-	EXPECT_EQ(out_config_.statements_.size(), 1);
+	EXPECT_EQ(out_config_.statements_.size(), 1); // config has one statement
 	EXPECT_EQ(out_config_.statements_.at(0)->tokens_.at(0), "foo");
 	EXPECT_EQ(out_config_.statements_.at(0)->tokens_.at(1), "bar");
 	EXPECT_EQ(out_config_.statements_.at(0)->child_block_,
-		std::unique_ptr<NginxConfig>());
+		std::unique_ptr<NginxConfig>()); // child block is empty
 }
 
-TEST_F(NginxStringConfigTest, InvalidConfig) {
+// Statements must end in semicolons
+TEST_F(NginxStringConfigTest, SimpleConfigInvalid) {
 	EXPECT_FALSE(ParseString("foo bar"));
 }
 
-TEST_F(NginxStringConfigTest, NestedConfig) {
+// Blocks with matching { and } brackets are valid
+TEST_F(NginxStringConfigTest, BlockConfigValid) {
 	EXPECT_TRUE(ParseString("server { listen 80; }"));
-	// TODO: test the contents of out_config_
 }
 
-TEST_F(NginxStringConfigTest, UnbalancedConfig) {
+// Blocks with unmatching brackets are invalid
+TEST_F(NginxStringConfigTest, BlockConfigInvalid) {
 	EXPECT_FALSE(ParseString("server { listen 80;"));
+	EXPECT_FALSE(ParseString("server listen 80;}"));
+}
+
+// Tests nested blocks
+TEST_F(NginxStringConfigTest, NestedConfigValid) {
+	EXPECT_TRUE(ParseString("server { foo {bar 80;}}"));
+}
+
+// Blocks that are incorrectly nested are invalid
+TEST_F(NginxStringConfigTest, NestedConfigInvalid) {
+	EXPECT_FALSE(ParseString("server { foo {bar 80;}"));
+	EXPECT_FALSE(ParseString("server { foo } bar 80;{"));
+	EXPECT_FALSE(ParseString("} foo { bar 80;}{"));
+}
+
+// Comments following a statement on the same line are valid
+TEST_F(NginxStringConfigTest, CommentOnLine) {
+	EXPECT_TRUE(ParseString("foo bar; # this is a comment."));
+	EXPECT_EQ(out_config_.statements_.size(), 1); // config has one statement
+}
+
+// Comments on separate lines are ignored by the parser
+TEST_F(NginxStringConfigTest, CommentOnLineAfter) {
+	EXPECT_TRUE(ParseString("foo bar; \n # this is a comment."));
+	EXPECT_EQ(out_config_.statements_.size(), 1); // config still has one statement
+}
+
+// Comments on separate lines are ignored by the parser
+TEST_F(NginxStringConfigTest, CommentOnLineBefore) {
+	EXPECT_TRUE(ParseString("# this is a comment. \n foo bar;"));
+	EXPECT_EQ(out_config_.statements_.size(), 1); // config has one statement
+}
+
+// A single comment in the file will result in a failed parsing
+// because there are no statements in the file
+TEST_F(NginxStringConfigTest, CommentAlone) {
+	EXPECT_FALSE(ParseString("# this is a comment."));
+	EXPECT_EQ(out_config_.statements_.size(), 0);
 }
 
 

--- a/config_parser_test.cc
+++ b/config_parser_test.cc
@@ -1,11 +1,59 @@
 #include "gtest/gtest.h"
 #include "config_parser.h"
 
+/*****************************************************************************
+    BASIC TESTS
+*****************************************************************************/
+
 TEST(NginxConfigParserTest, SimpleConfig) {
   NginxConfigParser parser;
   NginxConfig out_config;
-
-  bool success = parser.Parse("example_config", &out_config);
-
-  EXPECT_TRUE(success);
+  EXPECT_TRUE(parser.Parse("example_config", &out_config));
 }
+
+TEST(NginxConfigParserTest, ToString) {
+	NginxConfigStatement statement;
+	statement.tokens_.push_back("foo");
+	statement.tokens_.push_back("bar");
+	EXPECT_EQ(statement.ToString(0), "foo bar;\n");
+}
+
+/*****************************************************************************
+    PARSING STRINGS
+*****************************************************************************/
+
+class NginxStringConfigTest : public ::testing::Test {
+protected:
+	bool ParseString(const std::string config_string) {
+		std::stringstream config_stream(config_string);
+		return parser_.Parse(&config_stream, &out_config_);
+	}
+	NginxConfigParser parser_;
+	NginxConfig out_config_;
+};
+
+TEST_F(NginxStringConfigTest, Statements) {
+	EXPECT_TRUE(ParseString("foo bar;"));
+	EXPECT_EQ(out_config_.statements_.size(), 1);
+	EXPECT_EQ(out_config_.statements_.at(0)->tokens_.at(0), "foo");
+	EXPECT_EQ(out_config_.statements_.at(0)->tokens_.at(1), "bar");
+	EXPECT_EQ(out_config_.statements_.at(0)->child_block_,
+		std::unique_ptr<NginxConfig>());
+}
+
+TEST_F(NginxStringConfigTest, InvalidConfig) {
+	EXPECT_FALSE(ParseString("foo bar"));
+}
+
+TEST_F(NginxStringConfigTest, NestedConfig) {
+	EXPECT_TRUE(ParseString("server { listen 80; }"));
+	// TODO: test the contents of out_config_
+}
+
+TEST_F(NginxStringConfigTest, UnbalancedConfig) {
+	EXPECT_FALSE(ParseString("server { listen 80;"));
+}
+
+
+
+


### PR DESCRIPTION
Fixed some bugs in the original code:
- "}" should be allowed to follow immediately after "}" (if there are nested blocks)
- Open and close brackets should be matched and properly nested

Introduced some simple test cases for the parser:
- Basic config with a single statement
- ToString method on simple config
- ToString method on config with a block
- Verify config parser correctly separates a simple statement into tokens
- Statements must end in semicolons
- Tests that blocks with matching { and } brackets are valid
- Tests that blocks with unmatching brackets are invalid
- Tests nested blocks
- Tests that blocks that are incorrectly nested are invalid
- Comments following a statement on the same line are valid
- Comments on separate lines are ignored by the parser
- Tests a config with a single comment and no statements
- Empty configs are invalid
- Test that whitespace gets removed correctly
- Test that new lines are handled correctly